### PR TITLE
ComScore Validation Fixes

### DIFF
--- a/BitmovinComscoreAnalytics/Classes/ComScoreBitmovinAdapter.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreBitmovinAdapter.swift
@@ -116,7 +116,7 @@ extension ComScoreBitmovinAdapter: PlayerListener {
     private func resume(){
         if player.isAd {
             playAdContentPart(duration: currentAdDuration, timeOffset: currentAdOffset)
-        }else {
+        } else {
             playVideoContentPart()
         }
     }


### PR DESCRIPTION
Fixing two issues reported by ComScore during their validation

- do not transition state when play / pause is called in an ad
- ad duration should be an integer