### PR TITLE
Add destroy API

### DIFF
--- a/BitmovinComscoreAnalytics/Classes/ComScoreBitmovinAdapter.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreBitmovinAdapter.swift
@@ -53,7 +53,6 @@ class ComScoreBitmovinAdapter: NSObject {
     }
 
     deinit {
-        self.player.remove(listener: self)
         destroy()
     }
 
@@ -63,6 +62,7 @@ class ComScoreBitmovinAdapter: NSObject {
     }
 
     func destroy() {
+        self.player.remove(listener: self)
         NotificationCenter.default.removeObserver(self,
                                                   name: UIApplication.willResignActiveNotification,
                                                   object: nil)

--- a/BitmovinComscoreAnalytics/Classes/ComScoreBitmovinAdapter.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreBitmovinAdapter.swift
@@ -53,17 +53,22 @@ class ComScoreBitmovinAdapter: NSObject {
     }
 
     deinit {
+        self.player.remove(listener: self)
+        destroy()
+    }
+
+    func update(metadata: ComScoreMetadata) {
+        self.dictionary = metadata.buildComScoreMetadataDictionary()
+        self.comScoreContentType = metadata.mediaType.toComScore()
+    }
+
+    func destroy() {
         NotificationCenter.default.removeObserver(self,
                                                   name: UIApplication.willResignActiveNotification,
                                                   object: nil)
         NotificationCenter.default.removeObserver(self,
                                                   name: UIApplication.willEnterForegroundNotification,
                                                   object: nil)
-    }
-
-    func update(metadata: ComScoreMetadata) {
-        self.dictionary = metadata.buildComScoreMetadataDictionary()
-        self.comScoreContentType = metadata.mediaType.toComScore()
     }
 
     func assetLength() -> TimeInterval {

--- a/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
@@ -9,7 +9,7 @@ import Foundation
 import BitmovinPlayer
 
 public class ComScoreStreamingAnalytics {
-    var comScoreAdapter: ComScoreBitmovinAdapter
+    let comScoreAdapter: ComScoreBitmovinAdapter
 
     // MARK: - initializer
     /**

--- a/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
@@ -23,6 +23,10 @@ public class ComScoreStreamingAnalytics {
         self.comScoreAdapter = ComScoreBitmovinAdapter(player: bitmovinPlayer, metadata: metadata)
     }
 
+    deinit {
+        self.comScoreAdapter.destroy()
+    }
+
     /**
      Destroys the ComScoreStreaming analytics object and unregisters it from the player
     */

--- a/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
@@ -9,7 +9,7 @@ import Foundation
 import BitmovinPlayer
 
 public class ComScoreStreamingAnalytics {
-    let comScoreAdapter: ComScoreBitmovinAdapter
+    var comScoreAdapter: ComScoreBitmovinAdapter
 
     // MARK: - initializer
     /**
@@ -21,6 +21,13 @@ public class ComScoreStreamingAnalytics {
      */
     init(bitmovinPlayer: BitmovinPlayer, metadata: ComScoreMetadata) {
         self.comScoreAdapter = ComScoreBitmovinAdapter(player: bitmovinPlayer, metadata: metadata)
+    }
+
+    /**
+     Destroys the ComScoreStreaming analytics object and unregisters it from the player
+    */
+    public func destroy() {
+        self.comScoreAdapter.destroy()
     }
 
     /**

--- a/Example/BitmovinComscoreAnalytics/Base.lproj/Main.storyboard
+++ b/Example/BitmovinComscoreAnalytics/Base.lproj/Main.storyboard
@@ -41,6 +41,14 @@
                                 <rect key="frame" x="231" y="32" width="48" height="30"/>
                                 <state key="normal" title="LIVE"/>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rcr-sl-lp4" userLabel="Recreate">
+                                <rect key="frame" x="286" y="32" width="61" height="30"/>
+                                <state key="normal" title="Recreate"/>
+                                <connections>
+                                    <action selector="recreateButtonClickedWithSender:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Jd9-bn-RPs"/>
+                                    <action selector="recreateButtonClickedWithSender:" destination="vXZ-lx-hvc" eventType="touchUpOutside" id="Z9P-bD-Dx8"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="252" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PM8-kh-a47">
                                 <rect key="frame" x="25" y="32" width="32" height="30"/>
                                 <state key="normal" title="VOD"/>
@@ -70,6 +78,7 @@
                         <constraints>
                             <constraint firstItem="1CD-o4-NTg" firstAttribute="bottom" secondItem="2fi-mo-0CV" secondAttribute="top" id="1jz-vo-9iS"/>
                             <constraint firstItem="zzQ-FK-KOf" firstAttribute="leading" secondItem="0qK-fB-hlo" secondAttribute="trailing" priority="900" constant="26" id="3bC-LJ-T03"/>
+                            <constraint firstItem="Rcr-sl-lp4" firstAttribute="centerY" secondItem="kIV-Jg-AD5" secondAttribute="centerY" id="7KT-Cl-jhw"/>
                             <constraint firstAttribute="trailing" secondItem="kIV-Jg-AD5" secondAttribute="trailing" priority="500" constant="745" id="Fsc-WT-jAf"/>
                             <constraint firstItem="0qK-fB-hlo" firstAttribute="leading" secondItem="PM8-kh-a47" secondAttribute="trailing" priority="900" constant="26" id="JaZ-nf-15P"/>
                             <constraint firstItem="PM8-kh-a47" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" constant="25" id="L60-Dp-VBR"/>
@@ -78,8 +87,10 @@
                             <constraint firstItem="1CD-o4-NTg" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="MWB-mZ-bGA"/>
                             <constraint firstItem="0qK-fB-hlo" firstAttribute="baseline" secondItem="PM8-kh-a47" secondAttribute="baseline" id="QuB-GY-Iko"/>
                             <constraint firstItem="1CD-o4-NTg" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" constant="8" symbolic="YES" id="S14-fO-Ab4"/>
+                            <constraint firstAttribute="trailing" secondItem="Rcr-sl-lp4" secondAttribute="trailing" constant="677" id="XfI-UY-kih"/>
                             <constraint firstItem="zzQ-FK-KOf" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" constant="12" id="aiX-Uz-gg3"/>
                             <constraint firstItem="kIV-Jg-AD5" firstAttribute="leading" secondItem="zzQ-FK-KOf" secondAttribute="trailing" constant="26" id="bPJ-DI-ktL"/>
+                            <constraint firstItem="Rcr-sl-lp4" firstAttribute="leading" secondItem="kIV-Jg-AD5" secondAttribute="trailing" constant="7" id="btl-fj-Apl"/>
                             <constraint firstAttribute="trailing" secondItem="1CD-o4-NTg" secondAttribute="trailing" id="w9j-2T-kw2"/>
                         </constraints>
                     </view>
@@ -93,7 +104,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="52.173913043478265" y="26.116071428571427"/>
+            <point key="canvasLocation" x="52.1484375" y="25.915080527086381"/>
         </scene>
     </scenes>
 </document>

--- a/Example/BitmovinComscoreAnalytics/ViewController.swift
+++ b/Example/BitmovinComscoreAnalytics/ViewController.swift
@@ -118,6 +118,30 @@ class ViewController: UIViewController {
         self.bitmovinPlayer?.unload()
     }
 
+    @IBAction func recreateButtonClicked(sender: UIButton) {
+        self.comScoreStreamingAnalytics?.destroy()
+        // Create a Comscore Configuration
+        let comScoreMetadata: ComScoreMetadata = ComScoreMetadata(mediaType: .longFormOnDemand,
+                                                                  publisherBrandName: "ABC",
+                                                                  programTitle: "Modern Family",
+                                                                  episodeTitle: "Rash Decisions",
+                                                                  episodeSeasonNumber: "1",
+                                                                  episodeNumber: "2",
+                                                                  contentGenre: "Comedy",
+                                                                  stationTitle: "Hulu",
+                                                                  completeEpisode: true)
+
+        // Create a ComScore Streaming Analytics
+        if let bitmovinPlayer = bitmovinPlayer {
+            do {
+                try comScoreStreamingAnalytics = ComScoreAnalytics.createComScoreStreamingAnalytics(bitmovinPlayer: bitmovinPlayer,
+                                                                                                    metadata: comScoreMetadata)
+            } catch {
+                print("ComScoreAnalytics must be started before creating a ComScoreStreamingAnalytics object")
+            }
+        }
+    }
+
     @IBAction func reloadButtonClicked(sender: UIButton) {
         destroyPlayer()
         createPlayer()


### PR DESCRIPTION
- Added API to destroy the ComScoreStreamingAnalytics object by removing itself as a listener to the bitmovin player. This was needed to properly turn off the ComScoreStreamingAnalytics object without destroying the BitmovinPlayer object