### PR TITLE
ComScore CCPA Updates

### DIFF
--- a/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
@@ -4,6 +4,7 @@ import BitmovinPlayer
 public final class ComScoreAnalytics {
     private static let serialQueue = DispatchQueue(label: "com.bitmovin.player.integrations.comscore.ComScoreAnalytics")
     private static var started: Bool = false
+    private static var configuration: ComScoreConfiguration? = nil
 
     /**
      Starts the ComScoreAnalytics monitoring. Must be called before creating a ComScoreStreamingAnalytics object
@@ -13,6 +14,7 @@ public final class ComScoreAnalytics {
     public static func start(configuration: ComScoreConfiguration) {
         serialQueue.sync {
             if !started {
+                ComScoreAnalytics.configuration = configuration
                 let builder = SCORPublisherConfigurationBuilder()
                 builder.publisherId = configuration.publisherId
                 builder.publisherSecret = configuration.publisherSecret
@@ -31,7 +33,7 @@ public final class ComScoreAnalytics {
 
     public static func createComScoreStreamingAnalytics(bitmovinPlayer: BitmovinPlayer, metadata: ComScoreMetadata) throws -> ComScoreStreamingAnalytics? {
         if started {
-            return ComScoreStreamingAnalytics(bitmovinPlayer: bitmovinPlayer, metadata: metadata)
+            return ComScoreStreamingAnalytics(bitmovinPlayer: bitmovinPlayer, configuration: ComScoreAnalytics.configuration!, metadata: metadata)
         } else {
             throw ComScoreError.notStarted
         }

--- a/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
@@ -17,6 +17,9 @@ public final class ComScoreAnalytics {
                 builder.publisherId = configuration.publisherId
                 builder.publisherSecret = configuration.publisherSecret
                 builder.applicationName = configuration.applicationName
+                if configuration.userConsent != .unknown {
+                    builder.persistentLabels = ["cs_ucfr": configuration.userConsent.rawValue]
+                }
                 SCORAnalytics.configuration()?.addClient(with: builder.build())
                 SCORAnalytics.start()
                 started = true

--- a/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
@@ -30,17 +30,30 @@ public final class ComScoreAnalytics {
             }
         }
     }
+
+    /**
+     Sets the user consent to granted. Use after the ComScoreAnalytics object has been started
+    */
+    public static func userConsentGranted() {
+        serialQueue.sync {
+            if started {
+                let publisherConfig = SCORAnalytics.configuration().publisherConfiguration(withPublisherId: ComScoreAnalytics.configuration!.publisherId)
+                publisherConfig?.setPersistentLabelWithName("cs_ucfr", value: ComScoreUserConsent.granted.rawValue)
+                SCORAnalytics.notifyHiddenEvent()
+            }
+        }
+    }
     
     /**
-     Updates the user consent.
-    - Parameters:
-    - configuration: The ComScoreConfiguration that contains your application specific information
+     Sets the user consent to denied. Use after the ComScoreAnalytics object has been started
     */
-    public static func updateUserConsent(configuration: ComScoreConfiguration) {
+    public static func userConsentDenied() {
         serialQueue.sync {
-            let publisherConfig = SCORAnalytics.configuration().publisherConfiguration(withPublisherId: configuration.publisherId)
-            publisherConfig?.setPersistentLabelWithName("cs_ucfr", value: configuration.userConsent.rawValue)
-            SCORAnalytics.notifyHiddenEvent()
+            if started {
+                let publisherConfig = SCORAnalytics.configuration().publisherConfiguration(withPublisherId: ComScoreAnalytics.configuration!.publisherId)
+                publisherConfig?.setPersistentLabelWithName("cs_ucfr", value: ComScoreUserConsent.denied.rawValue)
+                SCORAnalytics.notifyHiddenEvent()
+            }
         }
     }
 

--- a/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
@@ -37,7 +37,7 @@ public final class ComScoreAnalytics {
     public static func userConsentGranted() {
         serialQueue.sync {
             if started {
-                let publisherConfig = SCORAnalytics.configuration().publisherConfiguration(withPublisherId: ComScoreAnalytics.configuration!.publisherId)
+                let publisherConfig = SCORAnalytics.configuration().publisherConfiguration(withPublisherId: ComScoreAnalytics.configuration?.publisherId)
                 publisherConfig?.setPersistentLabelWithName("cs_ucfr", value: ComScoreUserConsent.granted.rawValue)
                 SCORAnalytics.notifyHiddenEvent()
             }
@@ -50,7 +50,7 @@ public final class ComScoreAnalytics {
     public static func userConsentDenied() {
         serialQueue.sync {
             if started {
-                let publisherConfig = SCORAnalytics.configuration().publisherConfiguration(withPublisherId: ComScoreAnalytics.configuration!.publisherId)
+                let publisherConfig = SCORAnalytics.configuration().publisherConfiguration(withPublisherId: ComScoreAnalytics.configuration?.publisherId)
                 publisherConfig?.setPersistentLabelWithName("cs_ucfr", value: ComScoreUserConsent.denied.rawValue)
                 SCORAnalytics.notifyHiddenEvent()
             }

--- a/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
@@ -4,7 +4,7 @@ import BitmovinPlayer
 public final class ComScoreAnalytics {
     private static let serialQueue = DispatchQueue(label: "com.bitmovin.player.integrations.comscore.ComScoreAnalytics")
     private static var started: Bool = false
-    private static var configuration: ComScoreConfiguration? = nil
+    private static var configuration: ComScoreConfiguration?
 
     /**
      Starts the ComScoreAnalytics monitoring. Must be called before creating a ComScoreStreamingAnalytics object

--- a/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
@@ -30,6 +30,19 @@ public final class ComScoreAnalytics {
             }
         }
     }
+    
+    /**
+     Updates the user consent.
+    - Parameters:
+    - configuration: The ComScoreConfiguration that contains your application specific information
+    */
+    public static func updateUserConsent(configuration: ComScoreConfiguration) {
+        serialQueue.sync {
+            let publisherConfig = SCORAnalytics.configuration().publisherConfiguration(withPublisherId: configuration.publisherId)
+            publisherConfig?.setPersistentLabelWithName("cs_ucfr", value: configuration.userConsent.rawValue)
+            SCORAnalytics.notifyHiddenEvent()
+        }
+    }
 
     public static func createComScoreStreamingAnalytics(bitmovinPlayer: BitmovinPlayer, metadata: ComScoreMetadata) throws -> ComScoreStreamingAnalytics? {
         if started {

--- a/BitmovinComscoreAnalytics/Classes/ComScoreConfiguration.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreConfiguration.swift
@@ -11,7 +11,7 @@ public class ComScoreConfiguration {
     public let publisherId: String
     public let publisherSecret: String
     public let applicationName: String
-    public let userConsent: ComScoreUserConsent
+    public var userConsent: ComScoreUserConsent
 
     // MARK: - initializer
     /**
@@ -20,7 +20,8 @@ public class ComScoreConfiguration {
      - Parameters:
      - publisherId: Publisher ID assigned by ComScore
      - publisherSecret: Publisher Secret assigned by ComScore
-     - applicationName: The name of your application that will be used for ComScore tracking     
+     - applicationName: The name of your application that will be used for ComScore tracking
+     - userConsent: Whether the user has given their consent to have data collected by ComScore
      */
     public init(publisherId: String, publisherSecret: String, applicationName: String, userConsent: ComScoreUserConsent = .unknown) {
         self.publisherId = publisherId

--- a/BitmovinComscoreAnalytics/Classes/ComScoreConfiguration.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreConfiguration.swift
@@ -11,6 +11,7 @@ public class ComScoreConfiguration {
     public let publisherId: String
     public let publisherSecret: String
     public let applicationName: String
+    public let userConsent: ComScoreUserConsent
 
     // MARK: - initializer
     /**
@@ -21,9 +22,10 @@ public class ComScoreConfiguration {
      - publisherSecret: Publisher Secret assigned by ComScore
      - applicationName: The name of your application that will be used for ComScore tracking     
      */
-    public init(publisherId: String, publisherSecret: String, applicationName: String) {
+    public init(publisherId: String, publisherSecret: String, applicationName: String, userConsent: ComScoreUserConsent = .unknown) {
         self.publisherId = publisherId
         self.publisherSecret = publisherSecret
         self.applicationName = applicationName
+        self.userConsent = userConsent
     }
 }

--- a/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
@@ -19,8 +19,8 @@ public class ComScoreStreamingAnalytics {
      - player: BitmovinPlayer instance to track
      - metadata: ComScore metadata associated with the content you are tracking
      */
-    init(bitmovinPlayer: BitmovinPlayer, metadata: ComScoreMetadata) {
-        self.comScoreAdapter = ComScoreBitmovinAdapter(player: bitmovinPlayer, metadata: metadata)
+    init(bitmovinPlayer: BitmovinPlayer, configuration: ComScoreConfiguration, metadata: ComScoreMetadata) {
+        self.comScoreAdapter = ComScoreBitmovinAdapter(player: bitmovinPlayer, configuration: configuration, metadata: metadata)
     }
 
     deinit {
@@ -40,5 +40,18 @@ public class ComScoreStreamingAnalytics {
     public func update(metadata: ComScoreMetadata) {
         comScoreAdapter.update(metadata: metadata)
     }
-
+    
+    /**
+     Sets the user consent value to granted
+    */
+    public func userConsentGranted() {
+        comScoreAdapter.userConsentGranted()
+    }
+    
+    /**
+     Sets the user consent value to denied
+    */
+    public func userConsentDenied() {
+        comScoreAdapter.userConsentDenied()
+    }
 }

--- a/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
@@ -40,14 +40,14 @@ public class ComScoreStreamingAnalytics {
     public func update(metadata: ComScoreMetadata) {
         comScoreAdapter.update(metadata: metadata)
     }
-    
+
     /**
      Sets the user consent value to granted
     */
     public func userConsentGranted() {
         comScoreAdapter.userConsentGranted()
     }
-    
+
     /**
      Sets the user consent value to denied
     */

--- a/ComScoreUserConsent.swift
+++ b/ComScoreUserConsent.swift
@@ -1,0 +1,12 @@
+//
+//  ComScoreUserConsent.swift
+//  BitmovinComScoreAnalytics-iOS
+//
+//  Created by aneurinc on 12/9/19.
+//
+
+public enum ComScoreUserConsent : String {
+    case denied = "0"
+    case granted = "1"
+    case unknown = "-1"
+}

--- a/Example/BitmovinComscoreAnalytics/AppDelegate.swift
+++ b/Example/BitmovinComscoreAnalytics/AppDelegate.swift
@@ -17,7 +17,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let comscoreConfiguration: ComScoreConfiguration = ComScoreConfiguration(publisherId: "YOUR_PUBLISHER_ID",
                                                                                  publisherSecret: "YOUR_PUBLISHER_SECRET",
-                                                                                 applicationName: "YOUR_APPLICATION_NAME")
+                                                                                 applicationName: "YOUR_APPLICATION_NAME",
+                                                                                 userConsent: .granted)
         ComScoreAnalytics.start(configuration: comscoreConfiguration)
 
         return true


### PR DESCRIPTION
Fixes [tub-lib/issues/429](https://github.com/TurnerOpenPlatform/tub-lib/issues/429#event-2864795748).

User consent is passed to ComScore via the `cs_ucfr` param. This can be achieved in two ways:
1. Via `ComScoreConfiguration` optional constructor param
2. By calling `userConsentGranted()` or `userConsentDenied()` on `ComScoreStreamingAnalytics` object