### PR TITLE
GH-500 modular stability updates

### DIFF
--- a/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreAnalytics.swift
@@ -70,6 +70,7 @@ public final class ComScoreAnalytics {
     }
 }
 
+@frozen
 public enum ComScoreError: Error {
     case notStarted
 }

--- a/BitmovinComscoreAnalytics/Classes/ComScoreMetadata.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreMetadata.swift
@@ -9,6 +9,7 @@ import Foundation
 /**
  Metadata object describing the content that is being played back
  */
+@frozen
 public struct ComScoreMetadata {
     let mediaType: ComScoreMediaType
     let uniqueContentId: String?

--- a/BitmovinComscoreAnalytics/Classes/ComScoreUserConsent.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreUserConsent.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@frozen
 public enum ComScoreUserConsent: String {
     case denied = "0"
     case granted = "1"

--- a/BitmovinComscoreAnalytics/Classes/ComscoreMediaType.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComscoreMediaType.swift
@@ -11,6 +11,7 @@ import ComScore
 /**
  ComScoreMediaType associated with the content you have loaded into the BitmovinPlayer
  */
+@frozen
 public enum ComScoreMediaType: String {
     case longFormOnDemand
     case shortFormOnDemand

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - BitmovinComScoreAnalytics (1.3.0):
+  - BitmovinComScoreAnalytics (1.3.1):
     - BitmovinPlayer (~> 2.15)
     - ComScore (~> 5.8.7)
   - BitmovinPlayer (2.35.0)
@@ -7,7 +7,7 @@ PODS:
     - ComScore/Dynamic (= 5.8.7)
   - ComScore/Dynamic (5.8.7)
   - GoogleAds-IMA-iOS-SDK (3.7.0)
-  - SwiftLint (0.37.0)
+  - SwiftLint (0.38.2)
 
 DEPENDENCIES:
   - BitmovinComScoreAnalytics (from `../`)
@@ -35,11 +35,11 @@ CHECKOUT OPTIONS:
     :tag: 2.35.0
 
 SPEC CHECKSUMS:
-  BitmovinComScoreAnalytics: fc6ebb76cc1e4f330bf5057da5c245da3b308bfc
+  BitmovinComScoreAnalytics: fa25c6eb4ff707dd7203aac565099c1c21c2ed26
   BitmovinPlayer: ae4903f52305beb5cd98ed950de6fb3bb6c5f9a6
   ComScore: 4d377376e44c77de1e435a32fdf38d2507d6906c
   GoogleAds-IMA-iOS-SDK: cdc8901c00aa1aa4a383c9180df4c59bc94e2dcf
-  SwiftLint: c078a14d7d7ade75e5507795d185e3da41d844d2
+  SwiftLint: 8f5d2f903e1c9bcbc832fd16771e80a263ac6cbb
 
 PODFILE CHECKSUM: 8ebe3991a0fd552a368d954733f1d5a357713ab5
 


### PR DESCRIPTION
### Purpose
With modular stability on public value types (structs, enums) need to be frozen to avoid run time crashes on <= iOS 12. 

Modular Stability allows non-frozen enumerations that can grow over time. Implementors using these enums would add an `@unknown default` to catch new cases that could be added later by the library. This is helpful for integrators of server-side Swift, where Swift packages can be dynamically consumed without recompilation. For our use case - since integrators will always recompile on iOS - when added new props or cases to frozen types we can indicate through semantic versioning that there is a source breaking change. 

For more info see [`@frozen`](https://docs.swift.org/swift-book/ReferenceManual/Attributes.html#ID620) and [Switching Over Future Enumeration Cases](https://docs.swift.org/swift-book/ReferenceManual/Statements.html#ID602)

___

### Types that need to be changed:

**structs**: 
`ComScoreMetadata`

**enums**: 
`ComScoreError`, `ComScoreMediaType`, `ComScoreUserConsent`

___

I noticed that the default branch this PR is based off of is `master`... if this needs to be based off `develop` let me know. Also when performing a `pod install` some updates were made to the Podfile.lock.