### PR TITLE
Fix Ad Suppression

### DIFF
--- a/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
@@ -65,7 +65,7 @@ public class ComScoreStreamingAnalytics {
     }
     
     /**
-     Stop/resume ComScore streaming analytics tracking
+     Toggle ComScore streaming analytics tracking
      */
     public func suppressAnalytics(suppress: Bool) {
         adapter.suppressAnalytics = suppress

--- a/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
+++ b/BitmovinComscoreAnalytics/Classes/ComScoreStreamingAnalytics.swift
@@ -65,16 +65,9 @@ public class ComScoreStreamingAnalytics {
     }
     
     /**
-     Stop ComScore streaming analytics tracking
+     Stop/resume ComScore streaming analytics tracking
      */
-    public func stopTracking() {
-        adapter.stop()
-    }
-    
-    /**
-     Start ComScore streaming analytics tracking
-     */
-    public func startTracking() {
-        adapter.resume()
+    public func suppressAnalytics(suppress: Bool) {
+        adapter.suppressAnalytics = suppress
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.8.0]
+
+### Added
+- Suppress ComScore streaming analytics tracking API
+
+### Removed
+- Stop ComScore streaming analytics tracking API
+- Start ComScore streaming analytics tracking API
+
 ## [1.7.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.8.0]
+## [-]
 
 ### Added
 - Suppress ComScore streaming analytics tracking API


### PR DESCRIPTION
Previous PR did not fully suppress analytics. This PR adds a flag to prevent any streaming analytics beacons from firing.